### PR TITLE
Instance attributes usable as {placeholders} in host URL suffixes

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceUrlClosure.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceUrlClosure.java
@@ -60,19 +60,33 @@ public interface InstanceUrlClosure {
                 url = defaultUrlClosureConfig.get();
             }
 
+            if (url == null) {
+                throw new RuntimeException("Config property: " + urlClosureConfig.getName() + " or " +
+                        defaultUrlClosureConfig.getName() + " must be set");
+            }
+
+            url = processAttributeReplacements(host, url);
+
+            return "http://" + host.getHostname() + url;
+        }
+
+        /**
+         * Replaces any {placeholder} attributes in a url suffix using instance attributes
+         *
+         * e.x. :{server-port}/hystrix.stream -> :8080/hystrix.stream
+         *
+         * @param host instance
+         * @param url suffix
+         * @return replaced url suffix
+         */
+        private String processAttributeReplacements(Instance host, String url) {
             for (Map.Entry<String, String> attribute : host.getAttributes().entrySet()) {
                 String placeholder = "{"+attribute.getKey()+"}";
                 if (url.contains(placeholder)) {
                     url = url.replace(placeholder, attribute.getValue());
                 }
             }
-
-            if (url == null) {
-                throw new RuntimeException("Config property: " + urlClosureConfig.getName() + " or " + 
-                        defaultUrlClosureConfig.getName() + " must be set");
-            }
-            
-            return "http://" + host.getHostname() + url;
+            return url;
         }
     };
     


### PR DESCRIPTION
In the process of implementing a ZooKeeper instance discovery strategy, I found myself needing to dynamically replace the port Turbine uses to connect on a dynamic basis. This PR implements the ability to replace any instance attribute in the host URL suffix (e.x. {server-port}).

We run multiple workers per host machine (Storm) and embed a Jetty webserver which binds to any available port above a certain value. Given that multiple workers run per machine, the default port can often be used. We register this port in ZooKeeper but had no way to ask Turbine to connect to it.
