### PR TITLE
ZookeeperInstanceDiscovery

### DIFF
--- a/turbine-contrib/build.gradle
+++ b/turbine-contrib/build.gradle
@@ -9,5 +9,5 @@ apply plugin: 'eclipse'
         compile 'com.netflix.archaius:archaius-core:0.4.1'
         compile 'com.netflix.eureka:eureka-client:1.1.97'
         compile 'com.amazonaws:aws-java-sdk:1.4.5'
-        
+        compile 'com.netflix.curator:curator-x-discovery:1.3.3'
     }

--- a/turbine-contrib/src/main/java/com/netflix/turbine/discovery/ZookeeperInstanceDiscovery.java
+++ b/turbine-contrib/src/main/java/com/netflix/turbine/discovery/ZookeeperInstanceDiscovery.java
@@ -1,0 +1,114 @@
+package com.netflix.turbine.discovery;
+
+import com.google.common.collect.Lists;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.DynamicStringListProperty;
+import com.netflix.curator.framework.CuratorFramework;
+import com.netflix.curator.framework.CuratorFrameworkFactory;
+import com.netflix.curator.retry.ExponentialBackoffRetry;
+import com.netflix.curator.x.discovery.ServiceDiscovery;
+import com.netflix.curator.x.discovery.ServiceDiscoveryBuilder;
+import com.netflix.curator.x.discovery.ServiceInstance;
+import com.netflix.curator.x.discovery.details.ServiceCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * ZookeeperInstanceDiscovery
+ *
+ * Uses curator-x-discovery to discover nodes to poll with Turbine.
+ *
+ * Can monitor multiple clusters, but all must be under the same service discovery path.
+ *
+ * By default, will monitor /hystrix-event/{cluster}
+ *
+ * Archaius properties utilized:
+ *
+ * turbine.aggregator.clusterConfig (will monitor each cluster as a service under the serviceDiscoveryPath)
+ * turbine.ZookeeperInstanceDiscovery.zookeeper.quorum (default: 127.0.0.1)
+ * turbine.ZookeeperInstanceDiscovery.zookeeper.namespace (ZooKeeper namespace, none by default)
+ * turbine.ZookeeperInstanceDiscovery.zookeeper.serviceDiscoveryPath (default: /hystrix-event)
+ * turbine.ZookeeperInstanceDiscovery.zookeeper.connectTimeoutMs (default: 15000ms)
+ *
+ * Will only hit ZooKeeper when the watch registered on the various services triggers.
+ *
+ * @author Michael Rose <elementation@gmail.com>
+ */
+public class ZookeeperInstanceDiscovery implements InstanceDiscovery {
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final CuratorFramework zk;
+    private final ServiceDiscovery<Void> dsc;
+    private final List<ServiceCache<Void>> serviceCaches = Lists.newArrayList();
+
+    public ZookeeperInstanceDiscovery() throws Exception {
+        List<String> clusters =
+                new DynamicStringListProperty("turbine.aggregator.clusterConfig", new ArrayList<String>()).get();
+
+        String zkQuorum = DynamicPropertyFactory.getInstance()
+                .getStringProperty("turbine.ZookeeperInstanceDiscovery.zookeeper.quorum", "127.0.0.1").get();
+
+        String zkNamespace = DynamicPropertyFactory.getInstance()
+                .getStringProperty("turbine.ZookeeperInstanceDiscovery.zookeeper.namespace", null).get();
+
+        String serviceDiscoveryPath = DynamicPropertyFactory.getInstance()
+                .getStringProperty("turbine.ZookeeperInstanceDiscovery.zookeeper.serviceDiscoveryPath", "/hystrix-event").get();
+
+        int connectTimeoutMs = DynamicPropertyFactory.getInstance()
+                .getIntProperty("turbine.ZookeeperInstanceDiscovery.zookeeper.connectTimeoutMs", 15000).get();
+
+        log.info("Initializing ZookeeperInstanceDiscovery with quorum=[{}] namespace=[{}]",
+                new Object[]{zkQuorum, zkNamespace});
+
+        zk = CuratorFrameworkFactory.builder()
+                .connectString(zkQuorum)
+                .connectionTimeoutMs(connectTimeoutMs)
+                .retryPolicy(new ExponentialBackoffRetry(1000, 6))
+                .namespace(zkNamespace)
+                .build();
+
+        zk.start();
+
+        log.info("Initializing Service Discovery with serviceDiscoveryPath=[{}] and clusters={}",
+                new Object[]{serviceDiscoveryPath, clusters});
+
+        dsc = ServiceDiscoveryBuilder.builder(Void.class)
+                .basePath(serviceDiscoveryPath)
+                .client(zk)
+                .build();
+
+        dsc.start();
+
+        for (String cluster : clusters) {
+            ServiceCache<Void> serviceCache = dsc.serviceCacheBuilder()
+                    .name(cluster)
+                    .build();
+            serviceCache.start();
+
+            serviceCaches.add(serviceCache);
+        }
+
+    }
+
+    @Override
+    public Collection<Instance> getInstanceList() throws Exception {
+        List<Instance> collectedInstances = Lists.newArrayList();
+
+        for (ServiceCache<Void> serviceCache : serviceCaches) {
+            for (ServiceInstance<Void> serviceInstance : serviceCache.getInstances()) {
+                Instance instance = new Instance(
+                        serviceInstance.getAddress(),
+                        serviceInstance.getName(),
+                        true);
+                instance.getAttributes().put("server-port", serviceInstance.getPort().toString());
+
+                collectedInstances.add(instance);
+            }
+        }
+
+        return collectedInstances;
+    }
+}

--- a/turbine-contrib/src/main/java/com/netflix/turbine/discovery/ZookeeperInstanceDiscovery.java
+++ b/turbine-contrib/src/main/java/com/netflix/turbine/discovery/ZookeeperInstanceDiscovery.java
@@ -34,6 +34,12 @@ import java.util.List;
  * turbine.ZookeeperInstanceDiscovery.zookeeper.serviceDiscoveryPath (default: /hystrix-event)
  * turbine.ZookeeperInstanceDiscovery.zookeeper.connectTimeoutMs (default: 15000ms)
  *
+ * Instance properties added:
+ * server-port is initialized to the value of {@link com.netflix.curator.x.discovery.ServiceInstance#getPort()}
+ * ^ Can be used in your instanceUrlSuffix as so:
+ *
+ * turbine.instanceUrlSuffix=:{server-port}/hystrix.stream
+ *
  * Will only hit ZooKeeper when the watch registered on the various services triggers.
  *
  * @author Michael Rose <elementation@gmail.com>

--- a/turbine-contrib/src/main/java/com/netflix/turbine/discovery/ZookeeperInstanceDiscovery.java
+++ b/turbine-contrib/src/main/java/com/netflix/turbine/discovery/ZookeeperInstanceDiscovery.java
@@ -6,10 +6,10 @@ import com.netflix.config.DynamicStringListProperty;
 import com.netflix.curator.framework.CuratorFramework;
 import com.netflix.curator.framework.CuratorFrameworkFactory;
 import com.netflix.curator.retry.ExponentialBackoffRetry;
+import com.netflix.curator.x.discovery.ServiceCache;
 import com.netflix.curator.x.discovery.ServiceDiscovery;
 import com.netflix.curator.x.discovery.ServiceDiscoveryBuilder;
 import com.netflix.curator.x.discovery.ServiceInstance;
-import com.netflix.curator.x.discovery.details.ServiceCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/turbine-core/build.gradle
+++ b/turbine-core/build.gradle
@@ -13,4 +13,7 @@ apply plugin: 'eclipse'
         compile 'org.mockito:mockito-all:1.8.5'
         provided 'org.slf4j:slf4j-api:1.7.0'
         compile 'junit:junit:4.10'
+        compile 'com.netflix.curator:curator-framework:1.0.1'
+        compile 'com.netflix.curator:curator-client:1.0.1'
+        compile 'com.netflix.curator:curator-x-discovery:1.0.1'
     }

--- a/turbine-core/build.gradle
+++ b/turbine-core/build.gradle
@@ -13,7 +13,4 @@ apply plugin: 'eclipse'
         compile 'org.mockito:mockito-all:1.8.5'
         provided 'org.slf4j:slf4j-api:1.7.0'
         compile 'junit:junit:4.10'
-        compile 'com.netflix.curator:curator-framework:1.0.1'
-        compile 'com.netflix.curator:curator-client:1.0.1'
-        compile 'com.netflix.curator:curator-x-discovery:1.0.1'
     }

--- a/turbine-web/src/main/webapp/WEB-INF/classes/config.properties
+++ b/turbine-web/src/main/webapp/WEB-INF/classes/config.properties
@@ -41,3 +41,13 @@ eureka.serviceUrl.default=http://<eureka-host>/v2/
 #aws.accessKeyId=<AWS_ACCESS_KEY_ID>
 #aws.secretKey=<AWS_SECRET_KEY>
 #################################
+
+#################################
+# ZookeeperInstanceDiscovery
+# (Zookeeper impl only)
+# serviceName is set via clusterConfig
+#################################
+turbine.ZookeeperInstanceDiscovery.zookeeper.quorum=127.0.0.1
+#turbine.ZookeeperInstanceDiscovery.zookeeper.namespace=discovery
+#turbine.ZookeeperInstanceDiscovery.zookeeper.serviceDiscoveryPath=/hystrix-event
+#################################


### PR DESCRIPTION
Related to but not requiring https://github.com/Netflix/Turbine/pull/19 (sets a server-port instance attribute useful in instanceUrlSuffix)

Uses curator-x-discovery to find instances. Under a specific ZK directory (`turbine.ZookeeperInstanceDiscovery.zookeeper.serviceDiscoveryPath`) it will look for every cluster in `turbine.aggregator.clusterConfig`. Uses the ServiceCache around each ServiceDiscovery instance.

Feedback would be appreciated.
