### PR TITLE
Use private DNS name if public is not available.

### DIFF
--- a/turbine-contrib/src/main/java/com/netflix/turbine/discovery/AwsUtil.java
+++ b/turbine-contrib/src/main/java/com/netflix/turbine/discovery/AwsUtil.java
@@ -109,6 +109,10 @@ public class AwsUtil {
     		List<com.amazonaws.services.ec2.model.Instance> ec2Instances = reservation.getInstances();
     		for (com.amazonaws.services.ec2.model.Instance ec2Instance : ec2Instances) {
     			String hostname = ec2Instance.getPublicDnsName();
+    			if (hostname == null || hostname.length() == 0) {
+    				// This is primarily a solution for VPC deployments
+    				hostname =  ec2Instance.getPrivateDnsName();
+    			}
     			
     			String statusName = ec2Instance.getState().getName();
     			boolean status = statusName.equals("running"); // see com.amazonaws.services.ec2.model.InstanceState for values


### PR DESCRIPTION
This pull request is about improving the ASG based auto discovery in VPC environments:

In VPC based deployments, there is not necessarily a public DNS name for the monitored instance as it might live inside the VPC. In this scenario, the current implementation fails to construct a proper hostname.

However, the discovery might still be reachable via the private DNS name if the Turbine instance resides within the VPC as well. So, I added a fallback to the private DNS name.
