### PR TITLE
Typo in turbine.InstanceMonitor.hostRetryMillis dynamic property.

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/discovery/InstanceObservable.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/discovery/InstanceObservable.java
@@ -257,7 +257,7 @@ public class InstanceObservable {
             try {
                 newList = getInstanceList();
 
-                logger.info("Rertieved hosts from InstanceDiscovery: " + newList.size());
+                logger.info("Retrieved hosts from InstanceDiscovery: " + newList.size());
                 if(newList.size() < 10) {
                     logger.debug("Rertieved hosts from InstanceDiscovery: " + newList);
                 }

--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceMonitor.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceMonitor.java
@@ -123,7 +123,7 @@ public class InstanceMonitor extends TurbineDataMonitor<DataFromSingleInstance> 
     private static DynamicIntProperty latencyThreshold = DynamicPropertyFactory.getInstance().getIntProperty("turbine.InstanceMonitor.eventStream.skipLineLogic.latencyThreshold", 2500);
     // how long we should wait before processing lines again after a 'latencyThreshold' is met
     private static DynamicIntProperty skipLogicDelay = DynamicPropertyFactory.getInstance().getIntProperty("turbine.InstanceMonitor.eventStream.skipLineLogic.delay", 500);
-    private static DynamicIntProperty hostRetryMillis = DynamicPropertyFactory.getInstance().getIntProperty("turbine.InstanceMonitor.hostRertyMillis", 1000);
+    private static DynamicIntProperty hostRetryMillis = DynamicPropertyFactory.getInstance().getIntProperty("turbine.InstanceMonitor.hostRetryMillis", 1000);
 
     // Tracking state for InstanceMonitor
     private enum State {


### PR DESCRIPTION
 Additional mispellings.
