### PR TITLE
Add a configuration property to allow specifying a protocol, defaulting to http if none is specified.

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceUrlClosure.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceUrlClosure.java
@@ -67,7 +67,10 @@ public interface InstanceUrlClosure {
 
             url = processAttributeReplacements(host, url);
 
-            return "http://" + host.getHostname() + url;
+            String protocolKey = "turbine.protocol." + host.getCluster();
+            DynamicStringProperty protocolConfig = DynamicPropertyFactory.getInstance().getStringProperty(protocolKey, "http");
+
+            return protocolConfig.get() + "://" + host.getHostname() + url;
         }
 
         /**


### PR DESCRIPTION
We expose all our services over https, this change will allow us to specify the protocol to use when connecting to different clusters.
