### PR TITLE
javax.servlet:servlet-api should not be included in WAR

### DIFF
--- a/turbine-core/build.gradle
+++ b/turbine-core/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'eclipse'
         compile 'com.netflix.archaius:archaius-core:0.4.1'
         compile 'com.netflix.servo:servo-core:0.4.20'
         compile 'commons-io:commons-io:2.4'
-        compile 'javax.servlet:servlet-api:2.5'
+        provided 'javax.servlet:servlet-api:2.5'
         compile 'org.apache.httpcomponents:httpclient:4.2.1'
         compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
         compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'
@@ -14,3 +14,14 @@ apply plugin: 'eclipse'
         provided 'org.slf4j:slf4j-api:1.7.0'
         compile 'junit:junit:4.10'
     }
+
+    configurations {
+        provided
+    }
+
+
+    eclipse {
+        classpath {
+            plusConfigurations += configurations.provided
+    }
+}

--- a/turbine-web/build.gradle
+++ b/turbine-web/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'jetty'
 
     dependencies {
         compile project(":turbine-core")
+        provided 'javax.servlet:servlet-api:2.5'
         compile project(":turbine-contrib")
         compile 'com.netflix.eureka:eureka-client';        
         compile 'log4j:log4j:1.2.17'


### PR DESCRIPTION
I deployed the WAR on a tomcat and it complained that servlet-api was included in the WAR. 

I marked the dependency as "provided", now it's no longer included in the WAR.
