### PR TITLE
Adding TurbineInit.stop() to shut down all thread pools

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/data/meta/MetaInfoUpdator.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/data/meta/MetaInfoUpdator.java
@@ -12,29 +12,29 @@ import com.netflix.config.DynamicPropertyFactory;
 
 /**
  * Class that encapsulates a scheduled updator thread responsible for periodically sending meta info updates to interested parties.
- * It uses a timer task that runs once every second and sends updates downstream. 
+ * It uses a timer task that runs once every second and sends updates downstream.
  * The updator uses the register interface to discover the list of {@link MetaInformation} to update.
- * 
+ *
  * One can turn off this feature entirely by using the archaius property 'turbine.MetaInfoUpdator.enabled'
  * and one can control the frequency of the timer task using 'turbine.MetaInfoUpdator.runMillis'
- *  
+ *
  * @author poberai
  */
 public class MetaInfoUpdator {
-    
+
     // Fast property to turn meta updates ON/OFF
     private static final DynamicBooleanProperty UpdatorEnabled = DynamicPropertyFactory.getInstance().getBooleanProperty("turbine.MetaInfoUpdator.enabled", true);
     private static final DynamicIntProperty UpdatorFrequencyMillis = DynamicPropertyFactory.getInstance().getIntProperty("turbine.MetaInfoUpdator.runMillis", 1000);
-    
+
     // timer
     private final Timer timer = new Timer();
     // thread safe reference to the list of MetaInformation
-    private final AtomicReference<List<MetaInformation<?>>> metaInfoReference 
+    private final AtomicReference<List<MetaInformation<?>>> metaInfoReference
         = new AtomicReference<List<MetaInformation<?>>>(new ArrayList<MetaInformation<?>>());
-    
+
     // the singleton instance
     public static final MetaInfoUpdator Instance = new MetaInfoUpdator();
-    
+
     /**
      * Private constructor
      */
@@ -54,10 +54,10 @@ public class MetaInfoUpdator {
                     }
                 }
             }
-            
+
         }, 1000, UpdatorFrequencyMillis.get());
     }
-    
+
     /**
      * Register {@link MetaInformation} to be updated
      * @param metaInfo
@@ -82,6 +82,10 @@ public class MetaInfoUpdator {
         List<MetaInformation<?>> newList = new ArrayList<MetaInformation<?>>(Instance.metaInfoReference.get());
         newList.remove(metaInfo);
         Instance.metaInfoReference.set(newList);
+    }
+
+    public void stop() {
+        timer.cancel();
     }
 }
 

--- a/turbine-core/src/main/java/com/netflix/turbine/init/TurbineInit.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/init/TurbineInit.java
@@ -15,60 +15,93 @@
  */
 package com.netflix.turbine.init;
 
+import org.apache.commons.configuration.AbstractConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.netflix.config.ConcurrentCompositeConfiguration;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicConfiguration;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.config.DynamicStringProperty;
+import com.netflix.turbine.data.meta.MetaInfoUpdator;
 import com.netflix.turbine.discovery.ConfigPropertyBasedDiscovery;
 import com.netflix.turbine.discovery.FileBasedInstanceDiscovery;
 import com.netflix.turbine.discovery.InstanceDiscovery;
 import com.netflix.turbine.discovery.InstanceObservable;
 import com.netflix.turbine.monitor.cluster.AggregateClusterMonitor;
 import com.netflix.turbine.monitor.cluster.ClusterMonitorFactory;
+import com.netflix.turbine.monitor.instance.InstanceMonitor;
+import com.netflix.turbine.monitor.instance.StaleConnectionMonitorReaper;
 import com.netflix.turbine.plugins.DefaultAggregatorFactory;
 import com.netflix.turbine.plugins.PluginsFactory;
 
 /**
- * Class that is used to start Turbine. 
+ * Class that is used to start Turbine.
  * <p>Note that it needs an {@link InstanceDiscovery} to be registered for getting host information and {@link ClusterMonitorFactory}
- * as well to start the aggregation monitor. 
- * 
- * <p>By default the {@link FileBasedInstanceDiscovery} and the {@link AggregateClusterMonitor} are used. 
+ * as well to start the aggregation monitor.
+ *
+ * <p>By default the {@link FileBasedInstanceDiscovery} and the {@link AggregateClusterMonitor} are used.
  *
  */
 public class TurbineInit {
 
     private static final Logger logger = LoggerFactory.getLogger(TurbineInit.class);
-    
+
     private static final DynamicStringProperty InstanceDiscoveryClassProp = DynamicPropertyFactory.getInstance().getStringProperty("InstanceDiscovery.impl", null);
 
     @SuppressWarnings("rawtypes")
     public static void init() {
-        
+
         ClusterMonitorFactory clusterMonitorFactory = PluginsFactory.getClusterMonitorFactory();
         if(clusterMonitorFactory == null) {
             PluginsFactory.setClusterMonitorFactory(new DefaultAggregatorFactory());
         }
-        
+
         PluginsFactory.getClusterMonitorFactory().initClusterMonitors();
-        
+
         InstanceDiscovery instanceDiscovery = PluginsFactory.getInstanceDiscovery();
         if (instanceDiscovery == null) {
             PluginsFactory.setInstanceDiscovery(getInstanceDiscoveryImpl());
         }
-        
+
         InstanceObservable.getInstance().start(PluginsFactory.getInstanceDiscovery());
     }
-    
+
+    public static void stop() {
+
+        PluginsFactory.getClusterMonitorFactory().shutdownClusterMonitors();
+
+        InstanceMonitor.stop();
+
+        InstanceObservable.getInstance().stop();
+
+        StaleConnectionMonitorReaper.Instance.stop();
+
+        if (ConfigurationManager.getConfigInstance() instanceof DynamicConfiguration) {
+            ((DynamicConfiguration) ConfigurationManager.getConfigInstance()).stopLoading();
+        }
+
+        if (ConfigurationManager.getConfigInstance() instanceof ConcurrentCompositeConfiguration) {
+            ConcurrentCompositeConfiguration config = ((ConcurrentCompositeConfiguration) ConfigurationManager.getConfigInstance());
+            for(AbstractConfiguration innerConfig : config.getConfigurations()) {
+                if (innerConfig instanceof DynamicConfiguration) {
+                    ((DynamicConfiguration) innerConfig).stopLoading();
+                }
+            }
+        }
+
+        MetaInfoUpdator.Instance.stop();
+    }
+
     private static InstanceDiscovery getInstanceDiscoveryImpl() {
-        
-        String className = InstanceDiscoveryClassProp.get(); 
+
+        String className = InstanceDiscoveryClassProp.get();
         if (className == null) {
             logger.info("Property " + InstanceDiscoveryClassProp.getName() + " is not defined, hence using " + ConfigPropertyBasedDiscovery.class.getSimpleName() + " as InstanceDiscovery impl");
             return new ConfigPropertyBasedDiscovery();
         }
-        
+
         try {
             Class clazz = Class.forName(className);
             return (InstanceDiscovery) clazz.newInstance();

--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/cluster/ClusterMonitorFactory.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/cluster/ClusterMonitorFactory.java
@@ -19,8 +19,8 @@ import com.netflix.turbine.data.TurbineData;
 
 /**
  * An interface that encapsulated a factory for vending {@link ClusterMonitor} implementations.
- * <p>By default we use the {@link AggregateClusterMonitor} implementation if none other is specified. 
- * 
+ * <p>By default we use the {@link AggregateClusterMonitor} implementation if none other is specified.
+ *
  * @param <T>
  */
 public interface ClusterMonitorFactory<T extends TurbineData> {
@@ -30,9 +30,14 @@ public interface ClusterMonitorFactory<T extends TurbineData> {
      * @return {@link ClusterMonitor}<T>
      */
     public ClusterMonitor<T> getClusterMonitor(String name);
-    
+
     /**
      * Init all the necessary cluster monitors
      */
     public void initClusterMonitors();
+
+    /**
+     * shutdown all the necessary cluster monitors
+     */
+    public void shutdownClusterMonitors();
 }

--- a/turbine-web/src/main/java/com/netflix/turbine/StartTurbineServer.java
+++ b/turbine-web/src/main/java/com/netflix/turbine/StartTurbineServer.java
@@ -11,7 +11,7 @@ import com.netflix.turbine.init.TurbineInit;
 public class StartTurbineServer implements ServletContextListener {
 
     private static final Logger logger = LoggerFactory.getLogger(StartTurbineServer.class);
-    
+
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         logger.info("Initing Turbine server");
@@ -21,5 +21,6 @@ public class StartTurbineServer implements ServletContextListener {
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
         logger.info("Stopping Turbine server");
+        TurbineInit.stop();
     }
 }


### PR DESCRIPTION
I found that Turbine doesn't shutdown all the thread pools it starts. 

I fixed all thread pools until Tomcat didn't complain any more. 

Please have a look. If you think something is missing, please comment.

Br Alexander.
