### PR TITLE
Remove eureka-client dependency from turbine-web

### DIFF
--- a/turbine-web/build.gradle
+++ b/turbine-web/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'jetty'
     dependencies {
         compile project(":turbine-core")
         compile project(":turbine-contrib")
-        compile 'com.netflix.eureka:eureka-client';        
         compile 'log4j:log4j:1.2.17'
         compile 'org.slf4j:slf4j-log4j12:1.6.1'
     }


### PR DESCRIPTION
This dependency appears to have been added in error (it belongs only in turbine-contrib). It also currently stops turbine-war from being installed or deployed, since the lack of version number (on this dependency) causes Gradle to create an invalid pom.xml for turbine-web.
