### PR TITLE
using daemon threads for the InstanceMonitor for cleaner shutdown

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceMonitor.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceMonitor.java
@@ -111,6 +111,7 @@ public class InstanceMonitor extends TurbineDataMonitor<DataFromSingleInstance> 
 
         public Thread newThread(Runnable r) {
             Thread thread = defaultFactory.newThread(r);
+            thread.setDaemon(true);
             thread.setName(ThreadName);
             return thread;
         }


### PR DESCRIPTION
There are a few issues with a clean shutdown. One is the deadlock mentioned in https://github.com/Netflix/Turbine/issues/48 which only occurs sometimes. Another is that the InstanceMonitor does not cleanly shutdown. Making the instance monitor a daemon will ensure it doesn't keep the app running when it shuts down.
