### PR TITLE
replaced ivy-only syntax with equivalent maven-compatible syntax

### DIFF
--- a/turbine-core/build.gradle
+++ b/turbine-core/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.+'
+    compile 'io.reactivex:rxjava:[1.0,1.1)'
     compile 'com.netflix.rxnetty:rx-netty:0.3.18'
     compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'


### PR DESCRIPTION
Maven cannot parse the "1.0.+" dependency version in turbine-core. I've replaced the + syntax with [,) syntax, which maven and ivy can both parse.
