### PR TITLE
Use simpler takeUntil operator for group termination

### DIFF
--- a/turbine-core/build.gradle
+++ b/turbine-core/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    compile 'io.reactivex:rxjava:[1.0,1.1)'
+    compile 'io.reactivex:rxjava:1.0.8'
     compile 'com.netflix.rxnetty:rx-netty:0.3.18'
     compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'


### PR DESCRIPTION
This uses a new `takeUntil` operator added in RxJava 1.0.5: https://github.com/ReactiveX/RxJava/releases/tag/v1.0.5

It eliminates the need for "tombstone-end" so just a single "tombstone" can be used. 
