### PR TITLE
Added support for aggregating streams protected by basic auth

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/Turbine.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/Turbine.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2014 Netflix, Inc.
- * 
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,22 +15,6 @@
  */
 package com.netflix.turbine;
 
-import io.netty.buffer.ByteBuf;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
-import io.reactivex.netty.protocol.http.client.HttpClientRequest;
-import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import rx.Observable;
-import rx.observables.GroupedObservable;
-
 import com.netflix.turbine.aggregator.InstanceKey;
 import com.netflix.turbine.aggregator.StreamAggregator;
 import com.netflix.turbine.aggregator.TypeAndNameKey;
@@ -38,6 +22,20 @@ import com.netflix.turbine.discovery.StreamAction;
 import com.netflix.turbine.discovery.StreamAction.ActionType;
 import com.netflix.turbine.discovery.StreamDiscovery;
 import com.netflix.turbine.internal.JsonUtility;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.pipeline.PipelineConfigurators;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.observables.GroupedObservable;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.netflix.turbine.internal.RequestCreator.createRequest;
 
 public class Turbine {
 
@@ -60,7 +58,7 @@ public class Turbine {
                     .flatMap(data -> {
                         return response.writeAndFlush(new ServerSentEvent(null, null, JsonUtility.mapToJson(data)));
                     });
-        }, PipelineConfigurators.<ByteBuf> sseServerConfigurator()).startAndWait();
+        }, PipelineConfigurators.<ByteBuf>sseServerConfigurator()).startAndWait();
     }
 
     public static void startServerSentEventServer(int port, StreamDiscovery discovery) {
@@ -81,8 +79,7 @@ public class Turbine {
      * instanceId => Unique instance representing each stream to be merged, such as the instanceId of the server the stream is from.
      * type => The type of data such as HystrixCommand or HystrixThreadPool if aggregating Hystrix metrics.
      * name => Name of a group of metrics to be aggregated, such as a HystrixCommand name if aggregating Hystrix metrics.
-     * 
-     * 
+     *
      * @param uri
      * @return
      */
@@ -96,8 +93,8 @@ public class Turbine {
                     URI uri = streamAction.getUri();
 
                     Observable<Map<String, Object>> io = Observable.defer(() -> {
-                        Observable<Map<String, Object>> flatMap = RxNetty.createHttpClient(uri.getHost(), uri.getPort(), PipelineConfigurators.<ByteBuf> sseClientConfigurator())
-                                .submit(HttpClientRequest.createGet(uri.toASCIIString()))
+                        Observable<Map<String, Object>> flatMap = RxNetty.createHttpClient(uri.getHost(), uri.getPort(), PipelineConfigurators.<ByteBuf>sseClientConfigurator())
+                                .submit(createRequest(uri))
                                 .flatMap(response -> {
                                     if (response.getStatus().code() != 200) {
                                         return Observable.error(new RuntimeException("Failed to connect: " + response.getStatus()));
@@ -109,23 +106,24 @@ public class Turbine {
                                             .map(sse -> JsonUtility.jsonToMap(sse.getEventData()));
                                 });
                         // eclipse is having issues with type inference so breaking up 
-                            return flatMap.retryWhen(attempts -> {
-                                return attempts.flatMap(e -> {
-                                    return Observable.timer(1, TimeUnit.SECONDS)
-                                            .doOnEach(n -> logger.info("Turbine => Retrying connection to: " + uri));
-                                });
+                        return flatMap.retryWhen(attempts -> {
+                            return attempts.flatMap(e -> {
+                                return Observable.timer(1, TimeUnit.SECONDS)
+                                        .doOnEach(n -> logger.info("Turbine => Retrying connection to: " + uri));
                             });
-
                         });
+
+                    });
 
                     return GroupedObservable.from(InstanceKey.create(uri.toASCIIString()), io);
                 });
 
         return StreamAggregator.aggregateGroupedStreams(streamPerInstance);
     }
+
     /**
      * Aggregate multiple HTTP URIs
-     * 
+     *
      * @param uri
      * @return
      */

--- a/turbine-core/src/main/java/com/netflix/turbine/internal/RequestCreator.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/internal/RequestCreator.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.turbine.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class RequestCreator {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestCreator.class);
+
+    /**
+     * Creates a {@link HttpClientRequest} for the supplied URI.
+     * If user info is defined in the URI it'll be applied as basic authentication.
+     *
+     * @param uri The URI
+     * @return The generated {@link HttpClientRequest} with basic auth (if applicable)
+     */
+    public static HttpClientRequest<ByteBuf> createRequest(URI uri) {
+        String uriToUse = stripUserInfoFromUriIfDefined(uri).toASCIIString();
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.createGet(uriToUse);
+
+        if (uri.getUserInfo() != null) {
+            logger.debug("Adding basic authentication header for URI {}", uriToUse);
+            String basicAuth = "Basic " + Base64.getEncoder().encodeToString(uri.getUserInfo().getBytes(UTF_8));
+            request.withHeader("Authorization", basicAuth);
+        }
+
+        return request;
+    }
+
+    private static URI stripUserInfoFromUriIfDefined(URI uri) {
+        final URI uriToUse;
+        if (uri.getUserInfo() != null) {
+            try {
+                uriToUse = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            uriToUse = uri;
+        }
+        return uriToUse;
+    }
+}

--- a/turbine-core/src/test/java/com/netflix/turbine/internal/RequestCreatorTest.java
+++ b/turbine-core/src/test/java/com/netflix/turbine/internal/RequestCreatorTest.java
@@ -1,0 +1,59 @@
+package com.netflix.turbine.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+
+public class RequestCreatorTest {
+
+    private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+
+    @Test
+    public void doesntAddAuthorizationHeaderWhenNoUserInfoIsDefinedInUri() throws Exception {
+        // Given
+        URI uri = new URI("http://myapp.com");
+
+        // When
+        HttpClientRequest<ByteBuf> request = RequestCreator.createRequest(uri);
+
+        // Then
+        assertFalse(request.getHeaders().contains(AUTHORIZATION_HEADER_NAME));
+    }
+
+    @Test
+    public void addsAuthorizationHeaderWhenUserInfoIsDefinedInUri() throws Exception {
+        // Given
+        URI uri = new URI("http://username:password@myapp.com");
+
+        // When
+        HttpClientRequest<ByteBuf> request = RequestCreator.createRequest(uri);
+
+        // Then
+        assertEquals(basicAuthOf("username", "password"), request.getHeaders().getHeader(AUTHORIZATION_HEADER_NAME));
+    }
+
+    @Test
+    public void removesUserInfoFromUriWhenUserInfoIsDefinedInUri() throws Exception {
+        // Given
+        URI uri = new URI("http://username:password@myapp.com");
+
+        // When
+        HttpClientRequest<ByteBuf> request = RequestCreator.createRequest(uri);
+
+        // Then
+        assertFalse(request.getUri().contains("username:password@"));
+    }
+
+    private String basicAuthOf(String username, String password) {
+        return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(UTF_8));
+    }
+
+}


### PR DESCRIPTION
It's now possible to specify streams like http://username:password@mydomain.org. Username and password is applied as basic auth. 

For example `-streams "http://johan:password@mydomain.org"`
