### PR TITLE
Initialize the endpoint of the ec2 client in considering the region specified in properties

### DIFF
--- a/turbine-contrib/src/main/java/com/netflix/turbine/discovery/AwsUtil.java
+++ b/turbine-contrib/src/main/java/com/netflix/turbine/discovery/AwsUtil.java
@@ -48,12 +48,20 @@ public class AwsUtil {
     private final AmazonEC2Client ec2Client;
     
     public AwsUtil() {
-    	asgClient = new AmazonAutoScalingClient();
-    	ec2Client = new AmazonEC2Client();
-    	
-    	String endpoint = "autoscaling." + DynamicPropertyFactory.getInstance().getStringProperty("turbine.region", "us-east-1").get() + ".amazonaws.com";    	
-    	asgClient.setEndpoint(endpoint);    	
-    	logger.debug("Set the asgClient endpoint to [{}]", endpoint);
+        String region = DynamicPropertyFactory.getInstance().getStringProperty("turbine.region", "us-east-1").get();
+        String ec2Endpoint = "ec2." + region + ".amazonaws.com";
+
+        ec2Client = new AmazonEC2Client();
+        ec2Client.setEndpoint(ec2Endpoint);
+
+        logger.debug("Set the ec2Client ec2Endpoint to [{}]", ec2Endpoint);
+
+        String asgEndpoint = "autoscaling." + region + ".amazonaws.com";
+
+        asgClient = new AmazonAutoScalingClient();
+        asgClient.setEndpoint(asgEndpoint);
+
+    	logger.debug("Set the asgClient asgEndpoint to [{}]", asgEndpoint);
     }
 
     /**
@@ -112,10 +120,10 @@ public class AwsUtil {
     			
     			String statusName = ec2Instance.getState().getName();
     			boolean status = statusName.equals("running"); // see com.amazonaws.services.ec2.model.InstanceState for values
-    			
+
     			Instance turbineInstance = new Instance(hostname, asgName, status);
     			turbineInstance.getAttributes().put("asg", asgName);
-    			
+
     			turbineInstances.add(turbineInstance);
     		}    		
     	}


### PR DESCRIPTION
The property indicating the target region was used only to initialize the asg client. This pull request allows to initialize the ec2 client with the region specified in property. 

Feel free to accept or not this pull request.
