### PR TITLE
Avoid Java doc lint errors when building 1.x with Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,13 @@ apply from: file('gradle/maven.gradle')
 apply from: file('gradle/license.gradle')
 apply from: file('gradle/release.gradle')
 
+if (JavaVersion.current().isJava8Compatible()) {
+  allprojects {
+    tasks.withType(Javadoc) {
+      options.addStringOption('Xdoclint:none', '-quiet')
+    }
+  }
+}
 
 subprojects {
 


### PR DESCRIPTION
Related to #103.
