### PR TITLE
Support for same host different ports apps

### DIFF
--- a/turbine-core/src/main/java/com/netflix/turbine/discovery/Instance.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/discovery/Instance.java
@@ -77,7 +77,7 @@ public class Instance implements Comparable<Instance> {
         if(attributes != null && attributes.get("port") != null){
         	String port = attributes.get("port");
         	if(other.getAttributes() != null && other.getAttributes().get("port") != null){
-        		equals &= (port == other.getAttributes().get("port"));
+        		equals &= (port.equals(other.getAttributes().get("port")));
         	}
         }
 

--- a/turbine-core/src/main/java/com/netflix/turbine/discovery/Instance.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/discovery/Instance.java
@@ -74,6 +74,12 @@ public class Instance implements Comparable<Instance> {
         equals &= (this.hostname != null) ? (this.hostname.equals(other.hostname)) : (other.hostname == null);
         equals &= (this.cluster != null) ? (this.cluster.equals(other.cluster)) : (other.cluster == null);
         equals &= (this.isUp == other.isUp);
+        if(attributes != null && attributes.get("port") != null){
+        	String port = attributes.get("port");
+        	if(other.getAttributes() != null && other.getAttributes().get("port") != null){
+        		equals &= (port == other.getAttributes().get("port"));
+        	}
+        }
 
         return equals;
     }
@@ -85,6 +91,9 @@ public class Instance implements Comparable<Instance> {
         result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
         result = prime * result + ((cluster == null) ? 0 : cluster.hashCode());
         result = prime * result + (isUp ? 1 : 0);
+        if(attributes != null && attributes.get("port") != null){
+        	result = prime * result + (attributes.get("port").hashCode());
+        }
         return result;
     }
     

--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/cluster/ClusterMonitor.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/cluster/ClusterMonitor.java
@@ -294,8 +294,11 @@ public abstract class ClusterMonitor<K extends TurbineData> extends TurbineDataM
         }
         
         private TurbineDataMonitor<DataFromSingleInstance> getMonitor(Instance host) {
-            
-            TurbineDataMonitor<DataFromSingleInstance> monitor = hostConsole.findMonitor(host.getHostname());
+            String hostName = host.getHostname();
+            if(host.getAttributes() != null && host.getAttributes().get("port") != null){
+            	hostName += ":" + host.getAttributes().get("port");
+            }
+            TurbineDataMonitor<DataFromSingleInstance> monitor = hostConsole.findMonitor(hostName);
             if (monitor == null) {
                 monitor = new InstanceMonitor(host, urlClosure, hostDispatcher, hostConsole);
                 hostCount.incrementAndGet();

--- a/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceMonitor.java
+++ b/turbine-core/src/main/java/com/netflix/turbine/monitor/instance/InstanceMonitor.java
@@ -198,7 +198,11 @@ public class InstanceMonitor extends TurbineDataMonitor<DataFromSingleInstance> 
      */
     @Override
     public String getName() {
-        return host.getHostname();
+    	String hostName = host.getHostname();
+    	if(this.host.getAttributes() != null && this.host.getAttributes().get("port") != null){
+    		hostName += ":" + this.host.getAttributes().get("port");
+    	}
+        return hostName;
     }
 
     /**


### PR DESCRIPTION
This pull request solves the problem described in [issue 88](https://github.com/Netflix/Turbine/issues/88): being able to have different microservices deployed in the same host with different ports
